### PR TITLE
Add content pack support, update for SMAPI 3.0, fix crash

### DIFF
--- a/CritterEntry.cs
+++ b/CritterEntry.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CustomCritters
 {

--- a/CustomCritter.cs
+++ b/CustomCritter.cs
@@ -4,9 +4,6 @@ using StardewValley;
 using StardewValley.BellsAndWhistles;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CustomCritters
 {

--- a/CustomCritter.cs
+++ b/CustomCritter.cs
@@ -9,6 +9,10 @@ namespace CustomCritters
 {
     public class CustomCritter : Critter
     {
+        /// <summary>The light type IDs recognised by the game.</summary>
+        /// <remarks>Setting an invalid light ID will crash the game. Valid IDs are based on <see cref="LightSource.loadTextureFromConstantValue"/>.</remarks>
+        private readonly HashSet<int> validLightIds = new HashSet<int>(new[] { LightSource.lantern, LightSource.windowLight, LightSource.sconceLight, LightSource.cauldronLight, LightSource.indoorWindowLight });
+
         private CritterEntry data;
         private LightSource light;
         private Random rand;
@@ -35,10 +39,9 @@ namespace CustomCritters
             if ( data.Light != null )
             {
                 var col = new Color(255 - data.Light.Color.R, 255 - data.Light.Color.G, 255 - data.Light.Color.B);
-                if (data.Light.VanillaLightId != -1)
-                    light = new LightSource(data.Light.VanillaLightId, position, data.Light.Radius, col);
-                else
-                    light = new LightSource(4, position, data.Light.Radius, col);
+                light = this.validLightIds.Contains(data.Light.VanillaLightId) 
+                    ? new LightSource(data.Light.VanillaLightId, position, data.Light.Radius, col) 
+                    : new LightSource(LightSource.sconceLight, position, data.Light.Radius, col);
                 Game1.currentLightSources.Add(light);
             }
         }

--- a/CustomCritters.csproj
+++ b/CustomCritters.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>CustomCritters</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,18 +50,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
   <PropertyGroup>
     <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
 </Project>

--- a/CustomCritters.csproj
+++ b/CustomCritters.csproj
@@ -52,10 +52,7 @@
     <None Include="manifest.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
-  </PropertyGroup>
 </Project>

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CustomCritters
 {

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "Version": "1.2.5",
   "Description": "Lets you add custom critters to the world.",
   "UniqueID": "spacechase0.CustomCritters",
-  "PerSaveConfigs": false,
   "EntryDll": "CustomCritters.dll",
+  "MinimumApiVersion": "2.9.0",
   "UpdateKeys": [ "Nexus:1255", "Chucklefish:4791" ],
   "spacechase0": "custom-critters"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Name": "Custom Critters",
   "Author": "spacechase0",
   "Version": "1.2.5",
-  "Description": "...",
+  "Description": "Lets you add custom critters to the world.",
   "UniqueID": "spacechase0.CustomCritters",
   "PerSaveConfigs": false,
   "EntryDll": "CustomCritters.dll",

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
This pull request...

* Adds support for [standard content packs](https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Content_Packs).
* Updates the code for SMAPI 3.0 (still compatible with current versions of SMAPI).
* Updates the mod build package and simplifies the build settings.
* Migrates to the new package reference format.
* Fixes a crash if a critter has an invalid light type ID (affects [Cranber's Fireflies](https://www.nexusmods.com/stardewvalley/mods/1377)).
* Adds a description to the `manifest.json`.

Let me know if you want me to change anything!